### PR TITLE
上位の「node engine」の制限を解除

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "payjp",
     "react-component"
   ],
-  "engines" : { "node" : ">=7.0.0 <8.1.3" },
+  "engines" : { "node" : ">=7.0.0" },
   "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,7 +1170,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-"cell@github:jkroso/cell":
+cell@jkroso/cell:
   version "1.0.2"
   resolved "https://codeload.github.com/jkroso/cell/tar.gz/6db4991ebff09e344d7c1211c4abdcc62aff479e"
 
@@ -3512,7 +3512,7 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
-"merge@github:yields/merge":
+merge@yields/merge:
   version "1.0.1"
   resolved "https://codeload.github.com/yields/merge/tar.gz/2f357cb501cd06f1a86394b7817e5df73c53f644"
 


### PR DESCRIPTION
こんにちは、このライブラリを作っていただきありがとうございます。

このライブラリは、消費者に警告を出す前に、Nodeバージョン8.1.3までしか許可していないことに気づきました。これは非常に古いバージョンのNodeであり、私はこのような制限が必要だとは思いません。何か問題があれば教えてください。